### PR TITLE
Fix regex range in Dust grammar

### DIFF
--- a/syntaxes/igo-dust.tmLanguage.json
+++ b/syntaxes/igo-dust.tmLanguage.json
@@ -65,7 +65,7 @@
       ]
     },
     "dust_block_end": {
-      "begin": "(\\{~?/)([a-zA-Z0-9_\\.->]+)\\s*",
+      "begin": "(\\{~?/)([a-zA-Z0-9_\\.\\->]+)\\s*",
       "beginCaptures": {
         "1": {
           "name": "entity.name.tag.block.open.dust"


### PR DESCRIPTION
## Summary
- escape hyphen in `dust_block_end` regex to prevent unintended range

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6852b0d03c1c8323a5cf0774fb87ac29