### PR TITLE
Add clickable include links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,10 @@ This is the VS Code Language Support for [Igo Dust](https://github.com/igocreate
 
 This extension is based on the original [Dust Language Support extension](https://marketplace.visualstudio.com/items?itemName=nemesarial.dust) by Mark Holtzhausen.
 
+## Template Include Links
+
+When an Igo Dust template includes another template using the syntax
+`{> "path/to/template" /}` the path portion is now clickable. Clicking the
+path will open the referenced `.dust` file relative to the current template.
+
 **Enjoy!**

--- a/extension.js
+++ b/extension.js
@@ -1,0 +1,44 @@
+const vscode = require('vscode');
+const path = require('path');
+
+function activate(context) {
+  const provider = {
+    provideDocumentLinks(document) {
+      const links = [];
+      const text = document.getText();
+      const regex = /\{>\s*(?:"([^"\\]+)"|'([^'\\]+)'|([-a-zA-Z0-9_./]+))/g;
+      let match;
+      while ((match = regex.exec(text))) {
+        const targetPath = match[1] || match[2] || match[3];
+        const start = document.positionAt(match.index + match[0].indexOf(targetPath));
+        const end = document.positionAt(match.index + match[0].indexOf(targetPath) + targetPath.length);
+        const range = new vscode.Range(start, end);
+        const uri = resolveInclude(document.uri, targetPath);
+        links.push(new vscode.DocumentLink(range, uri));
+      }
+      return links;
+    }
+  };
+
+  context.subscriptions.push(
+    vscode.languages.registerDocumentLinkProvider({ language: 'igo-dust' }, provider)
+  );
+}
+
+function resolveInclude(baseUri, includePath) {
+  if (!includePath.endsWith('.dust')) {
+    includePath += '.dust';
+  }
+  if (includePath.startsWith('/')) {
+    const folder = vscode.workspace.getWorkspaceFolder(baseUri);
+    if (folder) {
+      return vscode.Uri.joinPath(folder.uri, includePath.slice(1));
+    }
+  }
+  const dir = path.dirname(baseUri.fsPath);
+  return vscode.Uri.file(path.join(dir, includePath));
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "igo-dust-language-support",
   "displayName": "Igo Dust Language Support",
   "description": "VS Code extension for igo-dust language support",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "IGOCREATE",
   "repository": {
     "type": "git",
@@ -12,6 +12,10 @@
   },
   "categories": [
     "Programming Languages"
+  ],
+  "main": "./extension.js",
+  "activationEvents": [
+    "onLanguage:igo-dust"
   ],
   "contributes": {
     "languages": [{


### PR DESCRIPTION
## Summary
- implement `DocumentLink` provider so `{> "foo" /}` include paths are clickable
- document the clickable include feature
- prepare extension entry point and activation
- bump extension version to 0.3.0

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab806a2b8832399edb7982a3b15fd